### PR TITLE
fix uprotocol zenoh key missmatch from uuri change

### DIFF
--- a/up_transport_zenoh/uptransportzenoh.py
+++ b/up_transport_zenoh/uptransportzenoh.py
@@ -326,7 +326,7 @@ class UPTransportZenoh(UTransport):
         if flag & (MessageFlag.PUBLISH | MessageFlag.NOTIFICATION):
             # Get Zenoh key
             zenoh_key = ZenohUtils.to_zenoh_key_string(self.authority_name, source_filter, sink_filter)
-            logging.debug("zenoh_key:" + zenoh_key)
+            logging.debug(f"Using zenoh key: {zenoh_key}")
             return self.register_publish_notification_listener(zenoh_key, listener)
 
     async def unregister_listener(

--- a/up_transport_zenoh/uptransportzenoh.py
+++ b/up_transport_zenoh/uptransportzenoh.py
@@ -326,6 +326,7 @@ class UPTransportZenoh(UTransport):
         if flag & (MessageFlag.PUBLISH | MessageFlag.NOTIFICATION):
             # Get Zenoh key
             zenoh_key = ZenohUtils.to_zenoh_key_string(self.authority_name, source_filter, sink_filter)
+            logging.debug("zenoh_key:" + zenoh_key)
             return self.register_publish_notification_listener(zenoh_key, listener)
 
     async def unregister_listener(

--- a/up_transport_zenoh/zenohutils.py
+++ b/up_transport_zenoh/zenohutils.py
@@ -45,18 +45,18 @@ class ZenohUtils:
     def uri_to_zenoh_key(authority_name: str, uri: UUri) -> str:
         authority = authority_name if not uri.authority_name else uri.authority_name
         ue_id = "*" if uri.ue_id == UriFactory.WILDCARD_ENTITY_ID else f"{uri.ue_id:X}"
+        if ue_id == "*":
+            ue_type = "*"  
+            ue_instance = "*"        
+        else: 
+            ue_id = int(ue_id) 
+            ue_type = (ue_id >> 16) & 0xFFFF  # Get upper 16 bits
+            ue_instance = ue_id & 0xFFFF      # Get lower 16 bits
         ue_version_major = (
             "*" if uri.ue_version_major == UriFactory.WILDCARD_ENTITY_VERSION else f"{uri.ue_version_major:X}"
         )
         resource_id = "*" if uri.resource_id == UriFactory.WILDCARD_RESOURCE_ID else f"{uri.resource_id:X}"
-        if ue_id == "*":
-            upper_16 = "*"  
-            lower_16 = "*"        
-        else: 
-            ue_id = int(ue_id)  # Convert string to integer
-            upper_16 = (ue_id >> 16) & 0xFFFF  # Get upper 16 bits
-            lower_16 = ue_id & 0xFFFF          # Get lower 16 bits
-        return f"{authority}/{upper_16}/{lower_16}/{ue_version_major}/{resource_id}"
+        return f"{authority}/{ue_type}/{ue_instance}/{ue_version_major}/{resource_id}"
 
     @staticmethod
     def get_uauth_from_uuri(uri: UUri) -> Union[str, UStatus]:

--- a/up_transport_zenoh/zenohutils.py
+++ b/up_transport_zenoh/zenohutils.py
@@ -49,9 +49,13 @@ class ZenohUtils:
             "*" if uri.ue_version_major == UriFactory.WILDCARD_ENTITY_VERSION else f"{uri.ue_version_major:X}"
         )
         resource_id = "*" if uri.resource_id == UriFactory.WILDCARD_RESOURCE_ID else f"{uri.resource_id:X}"
-        ue_id = int(ue_id)  # Convert string to integer
-        upper_16 = (ue_id >> 16) & 0xFFFF  # Get upper 16 bits
-        lower_16 = ue_id & 0xFFFF          # Get lower 16 bits
+        if ue_id == "*":
+            upper_16 = "*"  
+            lower_16 = "*"        
+        else: 
+            ue_id = int(ue_id)  # Convert string to integer
+            upper_16 = (ue_id >> 16) & 0xFFFF  # Get upper 16 bits
+            lower_16 = ue_id & 0xFFFF          # Get lower 16 bits
         return f"{authority}/{upper_16}/{lower_16}/{ue_version_major}/{resource_id}"
 
     @staticmethod

--- a/up_transport_zenoh/zenohutils.py
+++ b/up_transport_zenoh/zenohutils.py
@@ -27,7 +27,7 @@ from uprotocol.v1.uri_pb2 import UUri
 from uprotocol.v1.ustatus_pb2 import UStatus
 from zenoh import Priority, ZBytes
 
-UATTRIBUTE_VERSION: int = 1
+UATTRIBUTE_VERSION: int = 10
 
 # Configure the logging
 logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')

--- a/up_transport_zenoh/zenohutils.py
+++ b/up_transport_zenoh/zenohutils.py
@@ -49,7 +49,9 @@ class ZenohUtils:
             "*" if uri.ue_version_major == UriFactory.WILDCARD_ENTITY_VERSION else f"{uri.ue_version_major:X}"
         )
         resource_id = "*" if uri.resource_id == UriFactory.WILDCARD_RESOURCE_ID else f"{uri.resource_id:X}"
-        return f"{authority}/{ue_id}/{ue_version_major}/{resource_id}"
+        upper_16 = (ue_id >> 16) & 0xFFFF  # Get upper 16 bits
+        lower_16 = ue_id & 0xFFFF          # Get lower 16 bits
+        return f"{authority}/{upper_16}/{lower_16}/{ue_version_major}/{resource_id}"
 
     @staticmethod
     def get_uauth_from_uuri(uri: UUri) -> Union[str, UStatus]:

--- a/up_transport_zenoh/zenohutils.py
+++ b/up_transport_zenoh/zenohutils.py
@@ -46,12 +46,12 @@ class ZenohUtils:
         authority = authority_name if not uri.authority_name else uri.authority_name
         ue_id = "*" if uri.ue_id == UriFactory.WILDCARD_ENTITY_ID else f"{uri.ue_id:X}"
         if ue_id == "*":
-            ue_type = "*"  
-            ue_instance = "*"        
-        else: 
-            ue_id = int(ue_id) 
+            ue_type = "*"
+            ue_instance = "*"
+        else:
+            ue_id = int(ue_id)
             ue_type = (ue_id >> 16) & 0xFFFF  # Get upper 16 bits
-            ue_instance = ue_id & 0xFFFF      # Get lower 16 bits
+            ue_instance = ue_id & 0xFFFF  # Get lower 16 bits
         ue_version_major = (
             "*" if uri.ue_version_major == UriFactory.WILDCARD_ENTITY_VERSION else f"{uri.ue_version_major:X}"
         )
@@ -77,7 +77,9 @@ class ZenohUtils:
     @staticmethod
     def to_zenoh_key_string(authority_name: str, src_uri: UUri, dst_uri: UUri = None) -> str:
         src = ZenohUtils.uri_to_zenoh_key(authority_name, src_uri)
-        dst = ZenohUtils.uri_to_zenoh_key(authority_name, dst_uri) if dst_uri and dst_uri != UUri() else "{}/{}/{}/{}/{}"
+        dst = (
+            ZenohUtils.uri_to_zenoh_key(authority_name, dst_uri) if dst_uri and dst_uri != UUri() else "{}/{}/{}/{}/{}"
+        )
         return f"up/{src}/{dst}"
 
     @staticmethod

--- a/up_transport_zenoh/zenohutils.py
+++ b/up_transport_zenoh/zenohutils.py
@@ -49,6 +49,7 @@ class ZenohUtils:
             "*" if uri.ue_version_major == UriFactory.WILDCARD_ENTITY_VERSION else f"{uri.ue_version_major:X}"
         )
         resource_id = "*" if uri.resource_id == UriFactory.WILDCARD_RESOURCE_ID else f"{uri.resource_id:X}"
+        ue_id = int(ue_id)  # Convert string to integer
         upper_16 = (ue_id >> 16) & 0xFFFF  # Get upper 16 bits
         lower_16 = ue_id & 0xFFFF          # Get lower 16 bits
         return f"{authority}/{upper_16}/{lower_16}/{ue_version_major}/{resource_id}"

--- a/up_transport_zenoh/zenohutils.py
+++ b/up_transport_zenoh/zenohutils.py
@@ -77,7 +77,7 @@ class ZenohUtils:
     @staticmethod
     def to_zenoh_key_string(authority_name: str, src_uri: UUri, dst_uri: UUri = None) -> str:
         src = ZenohUtils.uri_to_zenoh_key(authority_name, src_uri)
-        dst = ZenohUtils.uri_to_zenoh_key(authority_name, dst_uri) if dst_uri and dst_uri != UUri() else "{}/{}/{}/{}"
+        dst = ZenohUtils.uri_to_zenoh_key(authority_name, dst_uri) if dst_uri and dst_uri != UUri() else "{}/{}/{}/{}/{}"
         return f"up/{src}/{dst}"
 
     @staticmethod


### PR DESCRIPTION
up-transport-zenoh-python uses an old version to generate the zenoh key from the uuri.
It only has `{authority}/{ue_id}/{ue_version_major}/{resource_id}`, but in newer versions the `ui_id `is split into `ue_type `and `ue_instance`:  `{authority}/{ue_type}/{ue_instance}/{ue_version_major}/{resource_id}` (e.g. see https://github.com/eclipse-uprotocol/up-transport-zenoh-rust/blob/fd98206c99fd075e9acf65eb56aa0a909985b003/src/utransport.rs#L85).
This makes the python implementation incompatible with newer implementations of other languages.
@PLeVasseur can probably give more context if needed.